### PR TITLE
fix(main.go): reverse order to show the winner first place

### DIFF
--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func sortKeyByValue(input map[int]int) []int {
 		keyValues = append(keyValues, KeyValue{Key: key, Value: value})
 	}
 	sort.Slice(keyValues, func(i, j int) bool {
-		return keyValues[i].Value > keyValues[j].Value
+		return keyValues[i].Value < keyValues[j].Value
 	})
 
 	var output []int


### PR DESCRIPTION
# Pull Request

## Description

Reverse order for the list of the days.

Before:

![image](https://github.com/user-attachments/assets/aeb25594-80f3-4403-b2a8-21819097aa3d)

After:

![image](https://github.com/user-attachments/assets/f5f33f78-dda7-49da-8a95-21770167c331)


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've run the command `go run main.go` as show in the documentation.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings